### PR TITLE
Fixed Add full-width image of a tiger below the News section

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
           <div class="latest-articles__card-squirrel"><h4 class="latest-articles__card-articles__title">Squirrel</h4><p class="latest-articles__card-text">Kamikaze squirrels</p></div>
           <div class="latest-articles__card-bird"><h4 class="latest-articles__card-articles__title">Bird</h4><p class="latest-articles__card-text">Birds Fight club</p></div>
         </div>
+        <img src="https://www.goodfreephotos.com/albums/animals/mammals/albino-tiger-resting.jpg" style="width:100%;">
       </div>
     </section>
 


### PR DESCRIPTION
Accidentally removed tiger when working on issue/8 and re-added it.

From reopened issue: https://github.com/memaraj/rscampgit/issues/9